### PR TITLE
New income shouldn't be the basis of the alerts

### DIFF
--- a/src/CookieMonster/interface/tooltips.js
+++ b/src/CookieMonster/interface/tooltips.js
@@ -244,8 +244,7 @@ CookieMonster.manageBuildingTooltip = function(building) {
  */
 CookieMonster.getLuckyAlerts = function(object) {
 	var price     = object.getPrice();
-	var newIncome = Game.cookiesPs + object.getWorth();
-	var rewards   = [this.getLuckyTreshold(false, newIncome), this.getLuckyTreshold('frenzy', newIncome)];
+	var rewards   = [this.getLuckyTreshold(false, Game.cookiesPs), this.getLuckyTreshold('frenzy', Game.cookiesPs)];
 	var deficits  = [0, 0];
 
 	// Check Lucky alert


### PR DESCRIPTION
If the cost of an item doesn't violate the current lucky threshold, it shouldn't matter to the player if it violates the new income (as the new income can sometimes be many times larger than the current one, e.g. when buying Reverse Cyclotrons).  They'll still be at least as good as they were before they bought the upgrade.
