### PR TITLE
Fix flashes on purchase, change variable name

### DIFF
--- a/src/CookieMonster/helpers/game.js
+++ b/src/CookieMonster/helpers/game.js
@@ -36,7 +36,7 @@ CookieMonster.simulateBuy = function(object, statistic) {
 		seasonUses       : Game.seasonUses,
 		achievements     : Game.Achievements,
 		achievementsOwned : Game.AchievementsOwned,
-		storeToRebuild   : Game.storeToRebuild,
+		storeToRefresh   : Game.storeToRefresh,
 		upgradesToRebuild : Game.upgradesToRebuild,
 	};
 
@@ -75,7 +75,7 @@ CookieMonster.simulateBuy = function(object, statistic) {
 	Game.seasonUses       = stored.seasonUses;
 	Game.Achievements     = stored.achievements;
 	Game.AchievementsOwned = stored.achievementsOwned;
-	Game.storeToRebuild   = stored.storeToRebuild;
+	Game.storeToRefresh   = stored.storeToRefresh;
 	Game.upgradesToRebuild = stored.upgradesToRebuild;
 	
 	// Restore native methods

--- a/src/CookieMonster/helpers/game.js
+++ b/src/CookieMonster/helpers/game.js
@@ -21,6 +21,7 @@ CookieMonster.simulateBuy = function(object, statistic) {
 		CollectWrinklers : Game.CollectWrinklers,
 		computeSeasonPrices : Game.computeSeasonPrices,
 		UpdateMenu  : Game.UpdateMenu,
+		seasonPopupReset : Game.seasonPopup.reset,
 	};
 	var stored = {
 		cpsSucked        : Game.cpsSucked,
@@ -47,6 +48,7 @@ CookieMonster.simulateBuy = function(object, statistic) {
 	Game.computeSeasonPrices = function() {};
 	Game.NewDrawFunction = function() {};
 	Game.UpdateMenu  = function() {};
+	Game.seasonPopup.reset = function() {};
 
 	// Simulate buy and store result
 	////////////////////////////////////////////////////////////////////
@@ -85,6 +87,7 @@ CookieMonster.simulateBuy = function(object, statistic) {
 	Game.computeSeasonPrices = swaped.computeSeasonPrices;
 	Game.NewDrawFunction = swaped.Draw;
 	Game.UpdateMenu  = swaped.UpdateMenu;
+	Game.seasonPopup.reset = swaped.seasonPopupReset;
 	
 	return income - Game[statistic];
 };


### PR DESCRIPTION
This should fix the screen flashes that occur every time a building/upgrade is purchased. Whenever CM simulates a buy, the CC buyfunction() calls Game.seasonPopup.reset(). This reset causes CM screen flash logic to execute. So I've disabled the reset() function during CM simulateBuy().

I also changed a variable name from 'storeToRebuild' to 'storeToRefresh' to match the variable name change in CC code.
