### PR TITLE
Add local web server and automatic recompilation to build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dist/cookie-monster.js
 .sass-cache
 npm-debug.log
 README.wiki
+
+# Vim swap/backup files
+*.*~
+*.*.swp

--- a/.grunt/development/connect.js
+++ b/.grunt/development/connect.js
@@ -1,0 +1,10 @@
+module.exports = {
+	options: {
+		hostname: 'localhost',
+		port: 8000,
+		base: 'dist/',
+	},
+
+	server: {}
+};
+

--- a/.grunt/development/watch.js
+++ b/.grunt/development/watch.js
@@ -14,6 +14,6 @@ module.exports = {
 	},
 	scripts: {
 		files: ['<%= paths.original.js %>/**/*', '<%= tests %>/**/**/*.js'],
-		tasks: ['js', 'uglify'],
+		tasks: ['js'],
 	},
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
 	////////////////////////////////////////////////////////////////////
 
 	grunt.registerTask('default', 'Build assets for local', [
-		'css', 'js',
+		'css', 'js', 'connect', 'watch',
 	]);
 
 	grunt.registerTask('test', 'Run the tests', [

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "grunt-contrib-jshint": "*",
     "grunt-contrib-uglify": "*",
     "grunt-contrib-watch": "*",
-    "grunt-contrib-watch": "*",
     "grunt-csscss": "*",
     "grunt-mocha-test": "*",
     "grunt-tinypng": "*",
     "jquery": "*",
     "jsdom": "*",
     "load-grunt-tasks": "*",
-    "mocha": "*"
+    "mocha": "*",
+    "grunt-contrib-connect": "~0.7.1"
   },
   "scripts": {
     "test": "./node_modules/.bin/grunt test"


### PR DESCRIPTION
I added grunt-contrib-connect so the project automatically starts a web server on port 8000 serving the `dist` directory. Additionally, I enabled grunt-contrib-watch so changes to the source trigger recompilation. 
