### PR TITLE
Fixes issue #31 - Two season upgrades not being removed from store

### DIFF
--- a/src/CookieMonster/core/hooks.js
+++ b/src/CookieMonster/core/hooks.js
@@ -41,6 +41,11 @@ CookieMonster.hookIntoNative = function() {
 		Game.Objects[i].cmType = "building";
 	}
 
+	//Add type for easier filtering later
+	for (i in Game.Upgrades) {
+		Game.Upgrades[i].cmType = "upgrade";
+	}
+
 	// Swap out the original Beautify for ours
 	Beautify = this.formatNumber;
 	this.replaceNative('Draw', {

--- a/src/CookieMonster/interface/buff-bars.js
+++ b/src/CookieMonster/interface/buff-bars.js
@@ -167,7 +167,7 @@ CookieMonster.manageTimersBar = function(name, label) {
 	}
 	
 	// Hide reindeer bar on other seasons
-	if (Game.season != "christmas" && name === 'seasonPopup') {
+	if (Game.season !== "christmas" && name === 'seasonPopup') {
 		return this.fadeOutBar(label);
 	}
 	
@@ -211,7 +211,7 @@ CookieMonster.updateBar = function (name, color, timer, width) {
 		this.fadeOutBar(identifier);
 	}
 
-	if (Game.season != "christmas" && name === 'seasonPopup') {
+	if (Game.season !== "christmas" && name === 'seasonPopup') {
 		this.fadeOutBar(identifier);
 	}
 	

--- a/src/CookieObject/helpers.js
+++ b/src/CookieObject/helpers.js
@@ -54,6 +54,13 @@ CookieObject.buyable = function() {
  * @return {Boolean}
  */
 CookieObject.isInStore = function() {
+	// This line added to account for upgrades that trigger a storeRefresh(which is usually triggered by building purchases).
+	// Upgrades like 'Season savings' and 'Santa's dominion' reduce building costs and trigger a storeRefresh
+	// which triggers a simulateBuy before Cookie Clicker code has removed the upgrade from the store. The simulateBuy
+	// resets the upgrade's bought variable back to 0 so it stays in the store when upgrades are rebuilt.
+	// This line prevents simulateBuy from being executed for upgrades where bought=1.
+	if(this.cmType === 'upgrade' && this.bought > 0) { return false; }
+
 	return Game.UpgradesInStore.indexOf(this) !== -1;
 };
 


### PR DESCRIPTION
This should resolve #31

Two Christmas upgrades were not being removed from the store after being clicked/purchased. They differ from other upgrades because they trigger a store Refresh (which is usually triggered by building purchases).
The upgrades 'Season savings' and 'Santa's dominion' reduce building costs and trigger a store Refresh which triggers CookieMonster simulateBuy() before Cookie Clicker code has removed the upgrade from the store. The simulateBuy() resets the upgrade's bought variable back to 0 so it stays in the store when upgrades are rebuilt.

To fix, I added a check in the isInStore() function to see if upgrade bought variable === 1. This prevents the simulateBuy() from executing for this upgrade (and some other functions in the stack that seems to be unnecessary for purchased upgrades e.g. tooltips).
